### PR TITLE
MCOL-641 Basic support for multi-value inserts, and deletes.

### DIFF
--- a/dbcon/ddlpackageproc/ddlpackageprocessor.cpp
+++ b/dbcon/ddlpackageproc/ddlpackageprocessor.cpp
@@ -1550,17 +1550,20 @@ void DDLPackageProcessor::updateSyscolumns(execplan::CalpontSystemCatalog::SCN t
     if (result.result != NO_ERROR)
         return;
 
-    WriteEngine::ColStructList  colStructs;
+    WriteEngine::ColStructList colStructs;
+    WriteEngine::CSCTypesList cscColTypeList;
     //std::vector<ColStruct> colStructs;
     WriteEngine::ColStruct colStruct;
+    execplan::CalpontSystemCatalog::ColType colType;
     WriteEngine::DctnryStructList dctnryStructList;
     WriteEngine::DctnryValueList dctnryValueList;
     //Build column structure for COLUMNPOS_COL
-    colStruct.dataOid = OID_SYSCOLUMN_COLUMNPOS;
-    colStruct.colWidth = 4;
+    colType.columnOID = colStruct.dataOid = OID_SYSCOLUMN_COLUMNPOS;
+    colType.colWidth = colStruct.colWidth = 4;
     colStruct.tokenFlag = false;
-    colStruct.colDataType = CalpontSystemCatalog::INT;
+    colType.colDataType = colStruct.colDataType = CalpontSystemCatalog::INT;
     colStructs.push_back(colStruct);
+    cscColTypeList.push_back(colType);
     int error;
     std::string err;
     std::vector<void*> colOldValuesList1;
@@ -1568,7 +1571,7 @@ void DDLPackageProcessor::updateSyscolumns(execplan::CalpontSystemCatalog::SCN t
     try
     {
         //@Bug 3051 use updateColumnRecs instead of updateColumnRec to use different value for diffrent rows.
-        if (NO_ERROR != (error = fWriteEngine.updateColumnRecs( txnID, colStructs, colValuesList, ridList )))
+        if (NO_ERROR != (error = fWriteEngine.updateColumnRecs( txnID, cscColTypeList, colStructs, colValuesList, ridList )))
         {
             // build the logging message
             WErrorCodes ec;

--- a/dbcon/dmlpackageproc/dmlpackageprocessor.h
+++ b/dbcon/dmlpackageproc/dmlpackageprocessor.h
@@ -478,7 +478,7 @@ protected:
     {
         if (((colType.colDataType == execplan::CalpontSystemCatalog::CHAR) && (colType.colWidth > 8))
                 || ((colType.colDataType == execplan::CalpontSystemCatalog::VARCHAR) && (colType.colWidth > 7))
-                || ((colType.colDataType == execplan::CalpontSystemCatalog::DECIMAL) && (colType.precision > 18))
+                || ((colType.colDataType == execplan::CalpontSystemCatalog::DECIMAL) && (colType.precision > 38))
                 || (colType.colDataType == execplan::CalpontSystemCatalog::VARBINARY)
                 || (colType.colDataType == execplan::CalpontSystemCatalog::BLOB)
                 || (colType.colDataType == execplan::CalpontSystemCatalog::TEXT))

--- a/primitives/linux-port/column.cpp
+++ b/primitives/linux-port/column.cpp
@@ -286,9 +286,7 @@ inline bool isEmptyVal<16>(uint8_t type, const uint8_t* ival) // For BINARY
 {
     const uint64_t* val = reinterpret_cast<const uint64_t*>(ival);
     // WIP ugly speed hack
-    return (((val[0] == joblist::BINARYEMPTYROW) && (val[1] == joblist::BINARYEMPTYROW))
-            || ((val[0] == joblist::BIGINTEMPTYROW) && (val[1] == joblist::BIGINTEMPTYROW)))
-;
+    return ((val[0] == joblist::BINARYEMPTYROW) && (val[1] == joblist::BINARYEMPTYROW));
 
 }
 

--- a/writeengine/server/we_ddlcommandproc.cpp
+++ b/writeengine/server/we_ddlcommandproc.cpp
@@ -141,6 +141,7 @@ uint8_t WE_DDLCommandProc::writeSystable(ByteStream& bs, std::string& err)
     WriteEngine::ColTuple colTuple;
     WriteEngine::ColStruct colStruct;
     WriteEngine::ColStructList colStructs;
+    WriteEngine::CSCTypesList cscColTypeList;
     WriteEngine::ColTupleList colTuples;
     WriteEngine::dictStr dctColTuples;
     WriteEngine::DctnryStruct dctnryStruct;
@@ -258,6 +259,7 @@ uint8_t WE_DDLCommandProc::writeSystable(ByteStream& bs, std::string& err)
             }
 
             colStructs.push_back(colStruct);
+            cscColTypeList.push_back(column.colType);
             oids[colStruct.dataOid] = colStruct.dataOid;
 
             //oidsToFlush.push_back(colStruct.dataOid);
@@ -296,7 +298,7 @@ uint8_t WE_DDLCommandProc::writeSystable(ByteStream& bs, std::string& err)
             // TODO: This may be redundant
             static boost::mutex dbrmMutex;
             boost::mutex::scoped_lock lk(dbrmMutex);
-            error = fWEWrapper.insertColumnRec_SYS(txnID, colStructs, colValuesList,
+            error = fWEWrapper.insertColumnRec_SYS(txnID, cscColTypeList, colStructs, colValuesList,
                                                    dctnryStructList, dctnryValueList, SYSCOLUMN_BASE);
 
             if (error != WriteEngine::NO_ERROR)
@@ -395,6 +397,7 @@ uint8_t WE_DDLCommandProc::writeCreateSyscolumn(ByteStream& bs, std::string& err
     WriteEngine::ColTuple colTuple;
     WriteEngine::ColStruct colStruct;
     WriteEngine::ColStructList colStructs;
+    WriteEngine::CSCTypesList cscColTypeList;
     WriteEngine::ColTupleList colTuples;
     WriteEngine::dictStr dctColTuples;
     WriteEngine::DctnryStruct dctnryStruct;
@@ -707,6 +710,7 @@ uint8_t WE_DDLCommandProc::writeCreateSyscolumn(ByteStream& bs, std::string& err
                 {
                     colStructs.push_back(colStruct);
                     dctnryStructList.push_back (dctnryStruct);
+                    cscColTypeList.push_back(column.colType);
                 }
 
                 colList[i].push_back(colTuple);
@@ -738,7 +742,7 @@ uint8_t WE_DDLCommandProc::writeCreateSyscolumn(ByteStream& bs, std::string& err
             }
 
             //fWEWrapper.setDebugLevel(WriteEngine::DEBUG_3);
-            error = fWEWrapper.insertColumnRec_SYS(txnID, colStructs, colValuesList,
+            error = fWEWrapper.insertColumnRec_SYS(txnID, cscColTypeList, colStructs, colValuesList,
                                                    dctnryStructList, dctnryValueList, SYSCOLUMN_BASE);
 
             if (idbdatafile::IDBPolicy::useHdfs())
@@ -824,6 +828,7 @@ uint8_t WE_DDLCommandProc::writeSyscolumn(ByteStream& bs, std::string& err)
     WriteEngine::ColStruct colStruct;
     WriteEngine::ColTuple colTuple;
     WriteEngine::ColStructList colStructs;
+    WriteEngine::CSCTypesList cscColTypeList;
     WriteEngine::ColTupleList colTuples;
     WriteEngine::DctColTupleList dctColTuples;
     WriteEngine::ColValueList colValuesList;
@@ -1098,6 +1103,7 @@ uint8_t WE_DDLCommandProc::writeSyscolumn(ByteStream& bs, std::string& err)
 
             colStructs.push_back(colStruct);
             dctnryStructList.push_back (dctnryStruct);
+            cscColTypeList.push_back(column.colType);
             colList[i].push_back(colTuple);
             //colList.push_back(WriteEngine::ColTupleList());
             //colList.back().push_back(colTuple);
@@ -1125,7 +1131,7 @@ uint8_t WE_DDLCommandProc::writeSyscolumn(ByteStream& bs, std::string& err)
             fWEWrapper.startTransaction(txnID);
             int rc1 = 0;
 
-            error = fWEWrapper.insertColumnRec_SYS(txnID, colStructs, colValuesList,
+            error = fWEWrapper.insertColumnRec_SYS(txnID, cscColTypeList, colStructs, colValuesList,
                                                    dctnryStructList, dctnryValueList, SYSCOLUMN_BASE);
 
             if (idbdatafile::IDBPolicy::useHdfs())
@@ -1375,7 +1381,9 @@ uint8_t WE_DDLCommandProc::deleteSyscolumn(ByteStream& bs, std::string& err)
 
         WriteEngine::ColStruct colStruct;
         WriteEngine::ColStructList colStructs;
+        WriteEngine::CSCTypesList cscColTypeList;
         std::vector<WriteEngine::ColStructList> colExtentsStruct;
+        std::vector<WriteEngine::CSCTypesList> colExtentsColType;
         std::vector<void*> colValuesList;
         WriteEngine::RIDList ridList;
         std::vector<WriteEngine::RIDList> ridLists;
@@ -1410,17 +1418,19 @@ uint8_t WE_DDLCommandProc::deleteSyscolumn(ByteStream& bs, std::string& err)
             oids[colStruct.dataOid] = colStruct.dataOid;
             //oidsToFlush.push_back(colStruct.dataOid);
             colStructs.push_back(colStruct);
+            cscColTypeList.push_back(column.colType);
 
             ++column_iterator;
         }
 
         colExtentsStruct.push_back(colStructs);
+        colExtentsColType.push_back(cscColTypeList);
         ridLists.push_back(ridList);
 
 
         if (0 != colStructs.size() && 0 != ridLists[0].size())
         {
-            int error = fWEWrapper.deleteRow(txnID, colExtentsStruct, colValuesList, ridLists, SYSCOLUMN_BASE);
+            int error = fWEWrapper.deleteRow(txnID, colExtentsColType, colExtentsStruct, colValuesList, ridLists, SYSCOLUMN_BASE);
 
             int rc1 = 0;
 
@@ -1515,7 +1525,9 @@ uint8_t WE_DDLCommandProc::deleteSyscolumnRow(ByteStream& bs, std::string& err)
 
         WriteEngine::ColStruct colStruct;
         WriteEngine::ColStructList colStructs;
+        WriteEngine::CSCTypesList cscColTypeList;
         std::vector<WriteEngine::ColStructList> colExtentsStruct;
+        std::vector<WriteEngine::CSCTypesList> colExtentsColType;
         std::vector<void*> colValuesList;
         WriteEngine::RIDList ridList;
         std::vector<WriteEngine::RIDList> ridLists;
@@ -1544,17 +1556,20 @@ uint8_t WE_DDLCommandProc::deleteSyscolumnRow(ByteStream& bs, std::string& err)
             oids[colStruct.dataOid] = colStruct.dataOid;
             //oidsToFlush.push_back(colStruct.dataOid);
             colStructs.push_back(colStruct);
+            cscColTypeList.push_back(column.colType);
 
             ++column_iterator;
         }
 
         colExtentsStruct.push_back(colStructs);
+        colExtentsColType.push_back(cscColTypeList);
         ridLists.push_back(ridList);
 
 
         if (0 != colStructs.size() && 0 != ridLists[0].size())
         {
-            int error = fWEWrapper.deleteRow(txnID, colExtentsStruct, colValuesList, ridLists, SYSCOLUMN_BASE);
+            int error = fWEWrapper.deleteRow(txnID, colExtentsColType, colExtentsStruct, colValuesList, ridLists, SYSCOLUMN_BASE);
+
             int rc1 = 0;
 
             if (idbdatafile::IDBPolicy::useHdfs())
@@ -1651,7 +1666,9 @@ uint8_t WE_DDLCommandProc::deleteSystable(ByteStream& bs, std::string& err)
 
         WriteEngine::ColStruct colStruct;
         WriteEngine::ColStructList colStructs;
+        WriteEngine::CSCTypesList cscColTypeList;
         std::vector<WriteEngine::ColStructList> colExtentsStruct;
+        std::vector<WriteEngine::CSCTypesList> colExtentsColType;
         std::vector<void*> colValuesList;
         WriteEngine::RIDList ridList;
         std::vector<WriteEngine::RIDList> ridLists;
@@ -1679,17 +1696,20 @@ uint8_t WE_DDLCommandProc::deleteSystable(ByteStream& bs, std::string& err)
             oids[colStruct.dataOid] = colStruct.dataOid;
             //oidsToFlush.push_back(colStruct.dataOid);
             colStructs.push_back(colStruct);
+            cscColTypeList.push_back(column.colType);
 
             ++column_iterator;
         }
 
         colExtentsStruct.push_back(colStructs);
+        colExtentsColType.push_back(cscColTypeList);
         ridLists.push_back(ridList);
 
 
         if (0 != colStructs.size() && 0 != ridLists[0].size())
         {
-            int error = fWEWrapper.deleteRow(txnID, colExtentsStruct, colValuesList, ridLists, SYSCOLUMN_BASE);
+            int error = fWEWrapper.deleteRow(txnID, colExtentsColType, colExtentsStruct, colValuesList, ridLists, SYSCOLUMN_BASE);
+
             int rc1 = 0;
 
             if (idbdatafile::IDBPolicy::useHdfs())
@@ -1762,7 +1782,9 @@ uint8_t WE_DDLCommandProc::deleteSystables(ByteStream& bs, std::string& err)
     systemCatalogPtr->identity(CalpontSystemCatalog::EC);
     WriteEngine::ColStruct colStruct;
     WriteEngine::ColStructList colStructs;
+    WriteEngine::CSCTypesList cscColTypeList;
     std::vector<WriteEngine::ColStructList> colExtentsStruct;
+    std::vector<WriteEngine::CSCTypesList> colExtentsColType;
     std::vector<void*> colValuesList;
     WriteEngine::RIDList ridList;
     std::vector<WriteEngine::RIDList> ridLists;
@@ -1811,16 +1833,19 @@ uint8_t WE_DDLCommandProc::deleteSystables(ByteStream& bs, std::string& err)
             oids[colStruct.dataOid] = colStruct.dataOid;
             //oidsToFlush.push_back(colStruct.dataOid);
             colStructs.push_back(colStruct);
+            cscColTypeList.push_back(column.colType);
 
             ++column_iterator;
         }
 
         colExtentsStruct.push_back(colStructs);
+        colExtentsColType.push_back(cscColTypeList);
         ridLists.push_back(ridList);
 
 
         {
-            int error = fWEWrapper.deleteRow(txnID, colExtentsStruct, colValuesList, ridLists, SYSCOLUMN_BASE);
+            int error = fWEWrapper.deleteRow(txnID, colExtentsColType, colExtentsStruct, colValuesList, ridLists, SYSCOLUMN_BASE);
+
             int rc1 = 0;
 
             if (idbdatafile::IDBPolicy::useHdfs())
@@ -1874,7 +1899,9 @@ uint8_t WE_DDLCommandProc::deleteSystables(ByteStream& bs, std::string& err)
         CalpontSystemCatalog::RIDList colRidList = systemCatalogPtr->columnRIDs(userTableName);
 
         colStructs.clear();
+        cscColTypeList.clear();
         colExtentsStruct.clear();
+        colExtentsColType.clear();
         colValuesList.clear();
         ridList.clear();
         ridLists.clear();
@@ -1909,17 +1936,20 @@ uint8_t WE_DDLCommandProc::deleteSystables(ByteStream& bs, std::string& err)
 
             colStructs.push_back(colStruct);
             oids[colStruct.dataOid] = colStruct.dataOid;
+            cscColTypeList.push_back(column.colType);
             //oidsToFlush.push_back(colStruct.dataOid);
             ++column_iterator;
         }
 
         colExtentsStruct.push_back(colStructs);
+        colExtentsColType.push_back(cscColTypeList);
         ridLists.push_back(ridList);
 
 
         if (0 != colStructs.size() && 0 != ridLists[0].size())
         {
-            int error = fWEWrapper.deleteRow(txnID, colExtentsStruct, colValuesList, ridLists, SYSCOLUMN_BASE);
+            int error = fWEWrapper.deleteRow(txnID, colExtentsColType, colExtentsStruct, colValuesList, ridLists, SYSCOLUMN_BASE);
+
             int rc1 = 0;
 
             if (idbdatafile::IDBPolicy::useHdfs())
@@ -2042,6 +2072,7 @@ uint8_t WE_DDLCommandProc::updateSyscolumnAuto(ByteStream& bs, std::string& err)
     WriteEngine::ColValueList colValuesList;
     WriteEngine::ColTupleList aColList;
     WriteEngine::ColStructList colStructs;
+    WriteEngine::CSCTypesList cscColTypeList;
     std::vector<void*> colOldValuesList;
     std::map<uint32_t, uint32_t> oids;
     //std::vector<BRM::OID_t>  oidsToFlush;
@@ -2082,6 +2113,7 @@ uint8_t WE_DDLCommandProc::updateSyscolumnAuto(ByteStream& bs, std::string& err)
     oids[colStruct.dataOid] = colStruct.dataOid;
     //oidsToFlush.push_back(colStruct.dataOid);
     dctnryStructList.push_back(dctnryStruct);
+    cscColTypeList.push_back(column.colType);
 
     for (unsigned int i = 0; i < roList.size(); i++)
     {
@@ -2090,6 +2122,7 @@ uint8_t WE_DDLCommandProc::updateSyscolumnAuto(ByteStream& bs, std::string& err)
 
     colValuesList.push_back(aColList);
     std::vector<WriteEngine::ColStructList> colExtentsStruct;
+    std::vector<WriteEngine::CSCTypesList> colExtentsColType;
     std::vector<WriteEngine::DctnryStructList> dctnryExtentsStruct;
     std::vector<extentInfo> extentsinfo;
     extentInfo aExtentinfo;
@@ -2132,13 +2165,14 @@ uint8_t WE_DDLCommandProc::updateSyscolumnAuto(ByteStream& bs, std::string& err)
 
         colExtentsStruct.push_back(colStructs);
         dctnryExtentsStruct.push_back(dctnryStructList);
+        colExtentsColType.push_back(cscColTypeList);
     }
 
     // call the write engine to update the row
     if (idbdatafile::IDBPolicy::useHdfs())
         fWEWrapper.startTransaction(txnID);
 
-    rc = fWEWrapper.updateColumnRec(txnID, colExtentsStruct, colValuesList, colOldValuesList,
+    rc = fWEWrapper.updateColumnRec(txnID, colExtentsColType, colExtentsStruct, colValuesList, colOldValuesList,
                                     ridLists, dctnryExtentsStruct, dctnryValueList, SYSCOLUMN_BASE);
 
     if (rc != NO_ERROR)
@@ -2233,6 +2267,7 @@ uint8_t WE_DDLCommandProc::updateSyscolumnNextvalCol(ByteStream& bs, std::string
     WriteEngine::ColValueList colValuesList;
     WriteEngine::ColTupleList aColList;
     WriteEngine::ColStructList colStructs;
+    WriteEngine::CSCTypesList cscColTypeList;
     std::vector<void*> colOldValuesList;
     std::map<uint32_t, uint32_t> oids;
     //std::vector<BRM::OID_t>  oidsToFlush;
@@ -2266,6 +2301,7 @@ uint8_t WE_DDLCommandProc::updateSyscolumnNextvalCol(ByteStream& bs, std::string
     //oidsToFlush.push_back(colStruct.dataOid);
     colStructs.push_back(colStruct);
     dctnryStructList.push_back(dctnryStruct);
+    cscColTypeList.push_back(column.colType);
 
     for (unsigned int i = 0; i < roList.size(); i++)
     {
@@ -2303,6 +2339,7 @@ uint8_t WE_DDLCommandProc::updateSyscolumnNextvalCol(ByteStream& bs, std::string
 
     std::vector<WriteEngine::RIDList> ridLists;
     std::vector<WriteEngine::ColStructList> colExtentsStruct;
+    std::vector<WriteEngine::CSCTypesList> colExtentsColType;
     std::vector<WriteEngine::DctnryStructList> dctnryExtentsStruct;
     ridLists.push_back(ridList);
 
@@ -2321,13 +2358,14 @@ uint8_t WE_DDLCommandProc::updateSyscolumnNextvalCol(ByteStream& bs, std::string
 
         colExtentsStruct.push_back(colStructs);
         dctnryExtentsStruct.push_back(dctnryStructList);
+        colExtentsColType.push_back(cscColTypeList);
     }
 
     // call the write engine to update the row
     fWEWrapper.setTransId(txnID);
     fWEWrapper.startTransaction(txnID);
 
-    rc = fWEWrapper.updateColumnRec(txnID, colExtentsStruct, colValuesList, colOldValuesList,
+    rc = fWEWrapper.updateColumnRec(txnID, colExtentsColType, colExtentsStruct, colValuesList, colOldValuesList,
                                     ridLists, dctnryExtentsStruct, dctnryValueList, SYSCOLUMN_BASE);
 
     if (rc != NO_ERROR)
@@ -2403,6 +2441,7 @@ uint8_t WE_DDLCommandProc::updateSyscolumnTablename(ByteStream& bs, std::string&
     WriteEngine::ColValueList colValuesList;
     WriteEngine::ColTupleList aColList;
     WriteEngine::ColStructList colStructs;
+    WriteEngine::CSCTypesList cscColTypeList;
     std::vector<void*> colOldValuesList;
     tableName.schema = CALPONT_SCHEMA;
     tableName.table = SYSCOLUMN_TABLE;
@@ -2470,6 +2509,7 @@ uint8_t WE_DDLCommandProc::updateSyscolumnTablename(ByteStream& bs, std::string&
 
     colStructs.push_back(colStruct);
     dctnryStructList.push_back(dctnryStruct);
+    cscColTypeList.push_back(column.colType);
 
     for (unsigned int i = 0; i < roList.size(); i++)
     {
@@ -2492,6 +2532,7 @@ uint8_t WE_DDLCommandProc::updateSyscolumnTablename(ByteStream& bs, std::string&
     std::vector<extentInfo> extentsinfo;
     extentInfo aExtentinfo;
     std::vector<WriteEngine::ColStructList> colExtentsStruct;
+    std::vector<WriteEngine::CSCTypesList> colExtentsColType;
     std::vector<WriteEngine::DctnryStructList> dctnryExtentsStruct;
 
     for (unsigned int i = 0; i < roList.size(); i++)
@@ -2528,6 +2569,7 @@ uint8_t WE_DDLCommandProc::updateSyscolumnTablename(ByteStream& bs, std::string&
 
         colExtentsStruct.push_back(colStructs);
         dctnryExtentsStruct.push_back(dctnryStructList);
+        colExtentsColType.push_back(cscColTypeList);
     }
 
     // call the write engine to update the row
@@ -2536,7 +2578,7 @@ uint8_t WE_DDLCommandProc::updateSyscolumnTablename(ByteStream& bs, std::string&
     fWEWrapper.setBulkFlag(false);
     fWEWrapper.startTransaction(txnID);
 
-    rc = fWEWrapper.updateColumnRec(txnID, colExtentsStruct, colValuesList, colOldValuesList,
+    rc = fWEWrapper.updateColumnRec(txnID, colExtentsColType, colExtentsStruct, colValuesList, colOldValuesList,
                                     ridLists, dctnryExtentsStruct, dctnryValueList, SYSCOLUMN_BASE);
 
     if (rc != NO_ERROR)
@@ -2632,6 +2674,7 @@ uint8_t WE_DDLCommandProc::updateSystableAuto(ByteStream& bs, std::string& err)
     WriteEngine::ColValueList colValuesList;
     WriteEngine::ColTupleList aColList;
     WriteEngine::ColStructList colStructs;
+    WriteEngine::CSCTypesList cscColTypeList;
     std::vector<void*> colOldValuesList;
     std::map<uint32_t, uint32_t> oids;
     //std::vector<BRM::OID_t>  oidsToFlush;
@@ -2665,12 +2708,14 @@ uint8_t WE_DDLCommandProc::updateSystableAuto(ByteStream& bs, std::string& err)
     }
 
     colStructs.push_back(colStruct);
+    cscColTypeList.push_back(column.colType);
     oids[colStruct.dataOid] = colStruct.dataOid;
     //oidsToFlush.push_back(colStruct.dataOid);
     dctnryStructList.push_back(dctnryStruct);
     aColList.push_back(colTuple);
     colValuesList.push_back(aColList);
     std::vector<WriteEngine::ColStructList> colExtentsStruct;
+    std::vector<WriteEngine::CSCTypesList> colExtentsColType;
     std::vector<WriteEngine::DctnryStructList> dctnryExtentsStruct;
 
 
@@ -2708,6 +2753,7 @@ uint8_t WE_DDLCommandProc::updateSystableAuto(ByteStream& bs, std::string& err)
         }
 
         colExtentsStruct.push_back(colStructs);
+        colExtentsColType.push_back(cscColTypeList);
         dctnryExtentsStruct.push_back(dctnryStructList);
     }
 
@@ -2717,7 +2763,7 @@ uint8_t WE_DDLCommandProc::updateSystableAuto(ByteStream& bs, std::string& err)
     fWEWrapper.setBulkFlag(false);
     fWEWrapper.startTransaction(txnID);
 
-    rc = fWEWrapper.updateColumnRec(txnID, colExtentsStruct, colValuesList, colOldValuesList,
+    rc = fWEWrapper.updateColumnRec(txnID, colExtentsColType, colExtentsStruct, colValuesList, colOldValuesList,
                                     ridLists, dctnryExtentsStruct, dctnryValueList, SYSCOLUMN_BASE);
 
     if (rc != NO_ERROR)
@@ -2811,6 +2857,7 @@ uint8_t WE_DDLCommandProc::updateSystableTablename(ByteStream& bs, std::string& 
     WriteEngine::ColValueList colValuesList;
     WriteEngine::ColTupleList aColList;
     WriteEngine::ColStructList colStructs;
+    WriteEngine::CSCTypesList cscColTypeList;
     std::vector<void*> colOldValuesList;
     std::map<uint32_t, uint32_t> oids;
     //std::vector<BRM::OID_t>  oidsToFlush;
@@ -2860,6 +2907,7 @@ uint8_t WE_DDLCommandProc::updateSystableTablename(ByteStream& bs, std::string& 
     colStructs.push_back(colStruct);
     dctnryStructList.push_back(dctnryStruct);
     oids[colStruct.dataOid] = colStruct.dataOid;
+    cscColTypeList.push_back(column.colType);
 
     //oidsToFlush.push_back(colStruct.dataOid);
     if (dctnryStruct.dctnryOid > 0)
@@ -2872,6 +2920,7 @@ uint8_t WE_DDLCommandProc::updateSystableTablename(ByteStream& bs, std::string& 
     colValuesList.push_back(aColList);
     std::vector<WriteEngine::ColStructList> colExtentsStruct;
     std::vector<WriteEngine::DctnryStructList> dctnryExtentsStruct;
+    std::vector<WriteEngine::CSCTypesList> colExtentsColType;
 
     dctColList = dictTuple;
     dctRowList.push_back(dctColList);
@@ -2907,6 +2956,7 @@ uint8_t WE_DDLCommandProc::updateSystableTablename(ByteStream& bs, std::string& 
 
         colExtentsStruct.push_back(colStructs);
         dctnryExtentsStruct.push_back(dctnryStructList);
+        colExtentsColType.push_back(cscColTypeList);
     }
 
     // call the write engine to update the row
@@ -2915,7 +2965,7 @@ uint8_t WE_DDLCommandProc::updateSystableTablename(ByteStream& bs, std::string& 
     fWEWrapper.setBulkFlag(false);
     fWEWrapper.startTransaction(txnID);
 
-    rc = fWEWrapper.updateColumnRec(txnID, colExtentsStruct, colValuesList, colOldValuesList,
+    rc = fWEWrapper.updateColumnRec(txnID, colExtentsColType, colExtentsStruct, colValuesList, colOldValuesList,
                                     ridLists, dctnryExtentsStruct, dctnryValueList, SYSCOLUMN_BASE);
 
     if (rc != NO_ERROR)
@@ -3039,6 +3089,7 @@ uint8_t WE_DDLCommandProc::updateSystablesTablename(ByteStream& bs, std::string&
     WriteEngine::ColValueList colValuesList;
     WriteEngine::ColTupleList aColList;
     WriteEngine::ColStructList colStructs;
+    WriteEngine::CSCTypesList cscColTypeList;
     std::vector<void*> colOldValuesList;
     std::map<uint32_t, uint32_t> oids;
     //std::vector<BRM::OID_t>  oidsToFlush;
@@ -3097,6 +3148,7 @@ uint8_t WE_DDLCommandProc::updateSystablesTablename(ByteStream& bs, std::string&
     colStructs.push_back(colStruct);
     dctnryStructList.push_back(dctnryStruct);
     oids[colStruct.dataOid] = colStruct.dataOid;
+    cscColTypeList.push_back(column.colType);
 
     //oidsToFlush.push_back(colStruct.dataOid);
     if (dctnryStruct.dctnryOid > 0)
@@ -3109,6 +3161,7 @@ uint8_t WE_DDLCommandProc::updateSystablesTablename(ByteStream& bs, std::string&
     colValuesList.push_back(aColList);
     std::vector<WriteEngine::ColStructList> colExtentsStruct;
     std::vector<WriteEngine::DctnryStructList> dctnryExtentsStruct;
+    std::vector<WriteEngine::CSCTypesList> colExtentsColType;
 
     dctColList = dictTuple;
     dctRowList.push_back(dctColList);
@@ -3144,6 +3197,7 @@ uint8_t WE_DDLCommandProc::updateSystablesTablename(ByteStream& bs, std::string&
 
         colExtentsStruct.push_back(colStructs);
         dctnryExtentsStruct.push_back(dctnryStructList);
+        colExtentsColType.push_back(cscColTypeList);
     }
 
     // call the write engine to update the row
@@ -3152,7 +3206,7 @@ uint8_t WE_DDLCommandProc::updateSystablesTablename(ByteStream& bs, std::string&
     fWEWrapper.setBulkFlag(false);
     fWEWrapper.startTransaction(txnID);
 
-    rc = fWEWrapper.updateColumnRec(txnID, colExtentsStruct, colValuesList, colOldValuesList,
+    rc = fWEWrapper.updateColumnRec(txnID, colExtentsColType, colExtentsStruct, colValuesList, colOldValuesList,
                                     ridLists, dctnryExtentsStruct, dctnryValueList, SYSCOLUMN_BASE);
 
     if (rc != NO_ERROR)
@@ -3214,6 +3268,7 @@ uint8_t WE_DDLCommandProc::updateSystablesTablename(ByteStream& bs, std::string&
     colValuesList.clear();
     aColList.clear();
     colStructs.clear();
+    cscColTypeList.clear();
     colOldValuesList.clear();
     oids.clear();
     tableName.schema = CALPONT_SCHEMA;
@@ -3294,6 +3349,7 @@ uint8_t WE_DDLCommandProc::updateSystablesTablename(ByteStream& bs, std::string&
 
     colStructs.push_back(colStruct);
     dctnryStructList.push_back(dctnryStruct);
+    cscColTypeList.push_back(column.colType);
 
     for (unsigned int i = 0; i < roList.size(); i++)
     {
@@ -3314,6 +3370,7 @@ uint8_t WE_DDLCommandProc::updateSystablesTablename(ByteStream& bs, std::string&
     dctnryValueList.push_back(dctRowList);
     extentsinfo.clear();
     colExtentsStruct.clear();
+    colExtentsColType.clear();
     dctnryExtentsStruct.clear();
     oid = 1021;
 
@@ -3351,10 +3408,11 @@ uint8_t WE_DDLCommandProc::updateSystablesTablename(ByteStream& bs, std::string&
 
         colExtentsStruct.push_back(colStructs);
         dctnryExtentsStruct.push_back(dctnryStructList);
+        colExtentsColType.push_back(cscColTypeList);
     }
 
     // call the write engine to update the row
-    rc = fWEWrapper.updateColumnRec(txnID, colExtentsStruct, colValuesList, colOldValuesList,
+    rc = fWEWrapper.updateColumnRec(txnID, colExtentsColType, colExtentsStruct, colValuesList, colOldValuesList,
                                     ridLists, dctnryExtentsStruct, dctnryValueList, SYSCOLUMN_BASE);
 
     if (rc != NO_ERROR)
@@ -3488,11 +3546,13 @@ uint8_t WE_DDLCommandProc::updateSyscolumnColumnposCol(messageqcpp::ByteStream& 
         WriteEngine::ColStruct colStruct;
         WriteEngine::DctnryStructList dctnryStructList;
         WriteEngine::DctnryValueList dctnryValueList;
+        WriteEngine::CSCTypesList cscColTypeList;
+        CalpontSystemCatalog::ColType colType;
         //Build column structure for COLUMNPOS_COL
-        colStruct.dataOid = OID_SYSCOLUMN_COLUMNPOS;
-        colStruct.colWidth = 4;
+        colType.columnOID = colStruct.dataOid = OID_SYSCOLUMN_COLUMNPOS;
+        colType.colWidth = colStruct.colWidth = 4;
         colStruct.tokenFlag = false;
-        colStruct.colDataType = CalpontSystemCatalog::INT;
+        colType.colDataType = colStruct.colDataType = CalpontSystemCatalog::INT;
         colStruct.fColDbRoot = dbRoot;
 
         if (idbdatafile::IDBPolicy::useHdfs())
@@ -3501,9 +3561,10 @@ uint8_t WE_DDLCommandProc::updateSyscolumnColumnposCol(messageqcpp::ByteStream& 
         }
 
         colStructs.push_back(colStruct);
+        cscColTypeList.push_back(colType);
         oids[colStruct.dataOid] = colStruct.dataOid;
         //oidsToFlush.push_back(colStruct.dataOid);
-        rc = fWEWrapper.updateColumnRecs( txnID, colStructs, colValuesList, ridList, SYSCOLUMN_BASE );
+        rc = fWEWrapper.updateColumnRecs( txnID, cscColTypeList, colStructs, colValuesList, ridList, SYSCOLUMN_BASE );
     }
 
     int rc1 = 0;
@@ -3599,7 +3660,7 @@ uint8_t WE_DDLCommandProc::fillNewColumn(ByteStream& bs, std::string& err)
     std::map<uint32_t, uint32_t> oids;
     oids[dataOid] = dataOid;
     oids[refColOID] = refColOID;
-    rc = fWEWrapper.fillColumn(txnID, dataOid, dataType, dataWidth, defaultVal, refColOID, refColDataType,
+    rc = fWEWrapper.fillColumn(txnID, dataOid, colType, defaultVal, refColOID, refColDataType,
                                refColWidth, refCompressionType, isNULL, compressionType, defaultValStr, dictOid, autoincrement);
 
     if ( rc != 0 )
@@ -4170,6 +4231,7 @@ uint8_t WE_DDLCommandProc::updateSyscolumnSetDefault(messageqcpp::ByteStream& bs
     WriteEngine::ColValueList colValuesList;
     WriteEngine::ColTupleList aColList1;
     WriteEngine::ColStructList colStructs;
+    WriteEngine::CSCTypesList cscColTypeList;
     std::vector<void*> colOldValuesList;
     WriteEngine::DctnryStructList dctnryStructList;
     WriteEngine::DctnryValueList dctnryValueList;
@@ -4275,6 +4337,7 @@ uint8_t WE_DDLCommandProc::updateSyscolumnSetDefault(messageqcpp::ByteStream& bs
 
     colStructs.push_back(colStruct);
     oids[colStruct.dataOid] = colStruct.dataOid;
+    cscColTypeList.push_back(column.colType);
 
     //oidsToFlush.push_back(colStruct.dataOid);
     if (dctnryStruct.dctnryOid > 0)
@@ -4306,6 +4369,7 @@ uint8_t WE_DDLCommandProc::updateSyscolumnSetDefault(messageqcpp::ByteStream& bs
 
     std::vector<WriteEngine::ColStructList> colExtentsStruct;
     std::vector<WriteEngine::DctnryStructList> dctnryExtentsStruct;
+    std::vector<WriteEngine::CSCTypesList> colExtentsColType;
     std::vector<WriteEngine::RIDList> ridLists;
     ridLists.push_back(ridList);
 
@@ -4336,11 +4400,12 @@ uint8_t WE_DDLCommandProc::updateSyscolumnSetDefault(messageqcpp::ByteStream& bs
 
         colExtentsStruct.push_back(colStructs);
         dctnryExtentsStruct.push_back(dctnryStructList);
+        colExtentsColType.push_back(cscColTypeList);
     }
 
     // call the write engine to update the row
 
-    if (NO_ERROR != fWEWrapper.updateColumnRec(txnID, colExtentsStruct, colValuesList, colOldValuesList,
+    if (NO_ERROR != fWEWrapper.updateColumnRec(txnID, colExtentsColType, colExtentsStruct, colValuesList, colOldValuesList,
             ridLists, dctnryExtentsStruct, dctnryValueList, SYSCOLUMN_BASE))
     {
         err = "WE: Update failed on: " + atableName.table;
@@ -4446,6 +4511,7 @@ uint8_t WE_DDLCommandProc::updateSyscolumnRenameColumn(messageqcpp::ByteStream& 
     WriteEngine::ColValueList colValuesList;
     WriteEngine::ColTupleList aColList1;
     WriteEngine::ColStructList colStructs;
+    WriteEngine::CSCTypesList cscColTypeList;
     std::vector<void*> colOldValuesList;
     std::map<uint32_t, uint32_t> oids;
     //std::vector<BRM::OID_t>  oidsToFlush;
@@ -4564,6 +4630,7 @@ uint8_t WE_DDLCommandProc::updateSyscolumnRenameColumn(messageqcpp::ByteStream& 
 
     colStructs.push_back(colStruct);
     oids[colStruct.dataOid] = colStruct.dataOid;
+    cscColTypeList.push_back(column1.colType);
 
     //oidsToFlush.push_back(colStruct.dataOid);
     if (dctnryStruct.dctnryOid > 0)
@@ -4601,6 +4668,7 @@ uint8_t WE_DDLCommandProc::updateSyscolumnRenameColumn(messageqcpp::ByteStream& 
 
     colStructs.push_back(colStruct);
     oids[colStruct.dataOid] = colStruct.dataOid;
+    cscColTypeList.push_back(column2.colType);
 
     //oidsToFlush.push_back(colStruct.dataOid);
     if (dctnryStruct.dctnryOid > 0)
@@ -4634,6 +4702,7 @@ uint8_t WE_DDLCommandProc::updateSyscolumnRenameColumn(messageqcpp::ByteStream& 
 
     colStructs.push_back(colStruct);
     oids[colStruct.dataOid] = colStruct.dataOid;
+    cscColTypeList.push_back(column3.colType);
 
     //oidsToFlush.push_back(colStruct.dataOid);
     if (dctnryStruct.dctnryOid > 0)
@@ -4668,6 +4737,7 @@ uint8_t WE_DDLCommandProc::updateSyscolumnRenameColumn(messageqcpp::ByteStream& 
 
     colStructs.push_back(colStruct);
     oids[colStruct.dataOid] = colStruct.dataOid;
+    cscColTypeList.push_back(column4.colType);
 
     //oidsToFlush.push_back(colStruct.dataOid);
     if (dctnryStruct.dctnryOid > 0)
@@ -4777,6 +4847,7 @@ uint8_t WE_DDLCommandProc::updateSyscolumnRenameColumn(messageqcpp::ByteStream& 
     colStructs.push_back(colStruct);
     dctnryStructList.push_back(dctnryStruct);
     oids[colStruct.dataOid] = colStruct.dataOid;
+    cscColTypeList.push_back(column5.colType);
 
     //oidsToFlush.push_back(colStruct.dataOid);
     if (dctnryStruct.dctnryOid > 0)
@@ -4804,6 +4875,7 @@ uint8_t WE_DDLCommandProc::updateSyscolumnRenameColumn(messageqcpp::ByteStream& 
     dctRowList.push_back(dctColList);
     dctnryValueList.push_back(dctRowList);
     std::vector<WriteEngine::ColStructList> colExtentsStruct;
+    std::vector<WriteEngine::CSCTypesList> colExtentsColType;
     std::vector<WriteEngine::DctnryStructList> dctnryExtentsStruct;
     std::vector<WriteEngine::RIDList> ridLists;
     ridLists.push_back(ridList);
@@ -4835,10 +4907,11 @@ uint8_t WE_DDLCommandProc::updateSyscolumnRenameColumn(messageqcpp::ByteStream& 
 
         colExtentsStruct.push_back(colStructs);
         dctnryExtentsStruct.push_back(dctnryStructList);
+        colExtentsColType.push_back(cscColTypeList);
     }
 
     // call the write engine to update the row
-    if (NO_ERROR != fWEWrapper.updateColumnRec(txnID, colExtentsStruct, colValuesList, colOldValuesList,
+    if (NO_ERROR != fWEWrapper.updateColumnRec(txnID, colExtentsColType, colExtentsStruct, colValuesList, colOldValuesList,
             ridLists, dctnryExtentsStruct, dctnryValueList, SYSCOLUMN_BASE))
     {
         err = "WE: Update failed on: " + atableName.table;

--- a/writeengine/server/we_dmlcommandproc.cpp
+++ b/writeengine/server/we_dmlcommandproc.cpp
@@ -113,7 +113,7 @@ uint8_t WE_DMLCommandProc::processSingleInsert(messageqcpp::ByteStream& bs, std:
     RowList rows = tablePtr->get_RowList();
 
     WriteEngine::ColStructList colStructs;
-    WriteEngine::CSCTypesList cscColTypes;
+    WriteEngine::CSCTypesList cscColTypeList;
     WriteEngine::DctnryStructList dctnryStructList;
     WriteEngine::DctnryValueList dctnryValueList;
     WriteEngine::ColValueList colValuesList;
@@ -138,7 +138,7 @@ uint8_t WE_DMLCommandProc::processSingleInsert(messageqcpp::ByteStream& bs, std:
             Row* rowPtr = rows.at(0);
             ColumnList columns = rowPtr->get_ColumnList();
             unsigned int numcols = rowPtr->get_NumberOfColumns();
-            cscColTypes.reserve(numcols);
+            cscColTypeList.reserve(numcols);
             // WIP
             // We presume that DictCols number is low
             colStructs.reserve(numcols);
@@ -156,7 +156,6 @@ uint8_t WE_DMLCommandProc::processSingleInsert(messageqcpp::ByteStream& bs, std:
                 CalpontSystemCatalog::ColType colType;
                 colType = systemCatalogPtr->colType(oid);
 
-                cscColTypes.push_back(colType);
                 WriteEngine::ColStruct colStruct;
                 colStruct.fColDbRoot = dbroot;
                 WriteEngine::DctnryStruct dctnryStruct;
@@ -166,7 +165,7 @@ uint8_t WE_DMLCommandProc::processSingleInsert(messageqcpp::ByteStream& bs, std:
                 colStruct.fCompressionType = colType.compressionType;
 
                 // Token
-                if ( isDictCol(colType) )
+                if (isDictCol(colType) )
                 {
                     // WIP Hardcoded value
                     colStruct.colWidth = 8;
@@ -196,6 +195,7 @@ uint8_t WE_DMLCommandProc::processSingleInsert(messageqcpp::ByteStream& bs, std:
 
                 colStructs.push_back(colStruct);
                 dctnryStructList.push_back(dctnryStruct);
+                cscColTypeList.push_back(colType);
 
                 ++column_iterator;
             }
@@ -535,7 +535,7 @@ uint8_t WE_DMLCommandProc::processSingleInsert(messageqcpp::ByteStream& bs, std:
     if (colValuesList[0].size() > 0)
     {
         if (NO_ERROR !=
-                (error = fWEWrapper.insertColumnRec_Single(txnid.id, cscColTypes, colStructs, colValuesList, dctnryStructList, dicStringList, tableRoPair.objnum)))
+                (error = fWEWrapper.insertColumnRec_Single(txnid.id, cscColTypeList, colStructs, colValuesList, dctnryStructList, dicStringList, tableRoPair.objnum)))
         {
             if (error == ERR_BRM_DEAD_LOCK)
             {
@@ -839,6 +839,7 @@ uint8_t WE_DMLCommandProc::processBatchInsert(messageqcpp::ByteStream& bs, std::
     bool isInsertSelect = insertPkg.get_isInsertSelect();
 
     WriteEngine::ColStructList colStructs;
+    WriteEngine::CSCTypesList cscColTypeList;
     WriteEngine::DctnryStructList dctnryStructList;
     WriteEngine::DctnryValueList dctnryValueList;
     WriteEngine::ColValueList colValuesList;
@@ -1043,7 +1044,7 @@ uint8_t WE_DMLCommandProc::processBatchInsert(messageqcpp::ByteStream& bs, std::
                 colStruct.fCompressionType = colType.compressionType;
 
                 // Token
-                if ( isDictCol(colType) )
+                if (isDictCol(colType) )
                 {
                     colStruct.colWidth = 8;
                     colStruct.tokenFlag = true;
@@ -1072,6 +1073,7 @@ uint8_t WE_DMLCommandProc::processBatchInsert(messageqcpp::ByteStream& bs, std::
 
                 colStructs.push_back(colStruct);
                 dctnryStructList.push_back(dctnryStruct);
+                cscColTypeList.push_back(colType);
 
                 ++column_iterator;
             }
@@ -1321,7 +1323,7 @@ uint8_t WE_DMLCommandProc::processBatchInsert(messageqcpp::ByteStream& bs, std::
             */
 
             if (NO_ERROR !=
-                    (error = fWEWrapper.insertColumnRecs(txnid.id, colStructs, colValuesList, dctnryStructList, dicStringList,
+                    (error = fWEWrapper.insertColumnRecs(txnid.id, cscColTypeList, colStructs, colValuesList, dctnryStructList, dicStringList,
                              dbRootExtTrackerVec, 0, bFirstExtentOnThisPM, isInsertSelect, isAutocommitOn, roPair.objnum, fIsFirstBatchPm)))
             {
                 if (error == ERR_BRM_DEAD_LOCK)
@@ -2686,6 +2688,7 @@ uint8_t WE_DMLCommandProc::processUpdate(messageqcpp::ByteStream& bs,
     WriteEngine::ColStruct colStruct;
     WriteEngine::ColValueList colValueList;
     WriteEngine::RIDList  rowIDLists;
+    WriteEngine::CSCTypesList cscColTypeList;
 
     WriteEngine::DctnryStructList dctnryStructList;
     WriteEngine::DctnryStruct dctnryStruct;
@@ -2853,7 +2856,7 @@ uint8_t WE_DMLCommandProc::processUpdate(messageqcpp::ByteStream& bs,
         colStruct.fCompressionType = colType.compressionType;
         tableColName.column  = columnsUpdated[j]->get_Name();
 
-        if ( !ridsFetched)
+        if (!ridsFetched)
         {
             // querystats
             uint64_t relativeRID = 0;
@@ -3771,12 +3774,13 @@ uint8_t WE_DMLCommandProc::processUpdate(messageqcpp::ByteStream& bs,
 
         colStructList.push_back(colStruct);
         colValueList.push_back (colTupleList);
+        cscColTypeList.push_back(colType);
     } //end of bulding values and column structure.
 
     //timer.stop("fetch values");
     if (rowIDLists.size() > 0)
     {
-        error = fWEWrapper.updateColumnRecs(txnId, colStructList, colValueList,  rowIDLists, tableRO.objnum);
+        error = fWEWrapper.updateColumnRecs(txnId, cscColTypeList, colStructList, colValueList,  rowIDLists, tableRO.objnum);
     }
 
     if (error != NO_ERROR)
@@ -4081,13 +4085,14 @@ uint8_t WE_DMLCommandProc::processDelete(messageqcpp::ByteStream& bs,
     for (uint32_t j = 0; j < row.getColumnCount(); j++)
     {
         preBlkNums[j] = -1;
-        colWidth[j] = (row.getColumnWidth(j) >= 8 ? 8 : row.getColumnWidth(j));
+        colWidth[j] = (row.getColumnWidth(j) >= 16 ? 16 : row.getColumnWidth(j));
     }
 
     //Get the file information from rowgroup
     dbRoot = rowGroups[txnId]->getDBRoot();
     rowGroups[txnId]->getLocation(&partition, &segment, &extentNum, &blockNum);
     WriteEngine::ColStructList colStructList;
+    WriteEngine::CSCTypesList cscColTypeList;
     WriteEngine::ColStruct colStruct;
     colStruct.fColPartition = partition;
     colStruct.fColSegment = segment;
@@ -4123,7 +4128,9 @@ uint8_t WE_DMLCommandProc::processDelete(messageqcpp::ByteStream& bs,
             colStruct.tokenFlag = false;
             colStruct.fCompressionType = colType.compressionType;
 
-            if (colType.colWidth > 8)  //token
+            if (colType.colWidth > 8 &&
+                !(colType.colDataType == CalpontSystemCatalog::DECIMAL ||
+                  colType.colDataType == CalpontSystemCatalog::UDECIMAL))  //token
             {
                 colStruct.colWidth = 8;
                 colStruct.tokenFlag = true;
@@ -4135,7 +4142,8 @@ uint8_t WE_DMLCommandProc::processDelete(messageqcpp::ByteStream& bs,
 
             colStruct.colDataType = colType.colDataType;
 
-            colStructList.push_back( colStruct );
+            colStructList.push_back(colStruct);
+            cscColTypeList.push_back(colType);
         }
     }
     catch (exception& ex)
@@ -4146,13 +4154,15 @@ uint8_t WE_DMLCommandProc::processDelete(messageqcpp::ByteStream& bs,
     }
 
     std::vector<ColStructList> colExtentsStruct;
+    std::vector<CSCTypesList> colExtentsColType;
     std::vector<void*> colOldValueList;
     std::vector<RIDList> ridLists;
     colExtentsStruct.push_back(colStructList);
+    colExtentsColType.push_back(cscColTypeList);
     ridLists.push_back(rowIDList);
     int error = 0;
 
-    error = fWEWrapper.deleteRow( txnId, colExtentsStruct, colOldValueList, ridLists, roPair.objnum );
+    error = fWEWrapper.deleteRow(txnId, colExtentsColType, colExtentsStruct, colOldValueList, ridLists, roPair.objnum);
 
     if (error != NO_ERROR)
     {

--- a/writeengine/server/we_dmlcommandproc.h
+++ b/writeengine/server/we_dmlcommandproc.h
@@ -110,8 +110,8 @@ private:
     {
         if (((colType.colDataType == execplan::CalpontSystemCatalog::CHAR) && (colType.colWidth > 8))
                 || ((colType.colDataType == execplan::CalpontSystemCatalog::VARCHAR) && (colType.colWidth > 7))
-                || ((colType.colDataType == execplan::CalpontSystemCatalog::DECIMAL) && (colType.precision > 65))
-                || ((colType.colDataType == execplan::CalpontSystemCatalog::UDECIMAL) && (colType.precision > 65))
+                || ((colType.colDataType == execplan::CalpontSystemCatalog::DECIMAL) && (colType.precision > 38))
+                || ((colType.colDataType == execplan::CalpontSystemCatalog::UDECIMAL) && (colType.precision > 38))
                 || (colType.colDataType == execplan::CalpontSystemCatalog::VARBINARY)
                 || (colType.colDataType == execplan::CalpontSystemCatalog::BLOB)
                 || (colType.colDataType == execplan::CalpontSystemCatalog::TEXT))

--- a/writeengine/shared/we_blockop.cpp
+++ b/writeengine/shared/we_blockop.cpp
@@ -82,6 +82,7 @@ bool BlockOp::calculateRowId(
  * RETURN:
  *    emptyVal - the value of empty row
  ***********************************************************/
+// TODO MCOL-641 Add support here
 uint64_t BlockOp::getEmptyRowValue(
     const CalpontSystemCatalog::ColDataType colDataType, const int width ) const
 {
@@ -138,8 +139,10 @@ uint64_t BlockOp::getEmptyRowValue(
                 emptyVal = joblist::SMALLINTEMPTYROW;
             else if ( width <= 4 )
                 emptyVal = joblist::INTEMPTYROW;
-            else
+            else if ( width <= 8 )
                 emptyVal = joblist::BIGINTEMPTYROW;
+            else
+                emptyVal = joblist::BINARYEMPTYROW;
 
             break;
 

--- a/writeengine/shared/we_convertor.cpp
+++ b/writeengine/shared/we_convertor.cpp
@@ -328,6 +328,7 @@ void Convertor::mapErrnoToString(int errNum, std::string& errString)
  *    none
  ******************************************************************************/
 /* static */
+// TODO MCOL-641
 void Convertor::convertColType(CalpontSystemCatalog::ColDataType dataType,
                                ColType& internalType, bool isToken)
 {
@@ -778,7 +779,6 @@ int Convertor::getCorrectRowWidth(CalpontSystemCatalog::ColDataType dataType, in
                 newWidth = 8;
             else
                 newWidth = 16;
-
             break;
 
         case CalpontSystemCatalog::DATE:

--- a/writeengine/wrapper/writeengine.h
+++ b/writeengine/wrapper/writeengine.h
@@ -163,12 +163,6 @@ public:
                                 ColTupleList& curTupleList, void* valArray,
                                 bool bFromList = true) ;
 
-    // WIP legacy
-    EXPORT void convertValArray(const size_t totalRow, 
-                                const ColType colType,
-                                ColTupleList& curTupleList, void* valArray,
-                                bool bFromList = true) ;
-
     /**
      * @brief Create a column, include object ids for column data and bitmap files
      * @param dataOid column datafile object id
@@ -195,8 +189,8 @@ public:
      * @param refColDataType Data-type of the referecne column
      * @param refColWidth Width of the reference column
      */
-    EXPORT int fillColumn(const TxnID& txnid, const OID& dataOid, execplan::CalpontSystemCatalog::ColDataType dataType,
-                          int dataWidth, ColTuple defaultVal,
+    EXPORT int fillColumn(const TxnID& txnid, const OID& dataOid, const execplan::CalpontSystemCatalog::ColType& colType,
+                          ColTuple defaultVal,
                           const OID& refColOID, execplan::CalpontSystemCatalog::ColDataType refColDataType,
                           int refColWidth, int refCompressionType, bool isNULL, int compressionType,
                           const std::string& defaultValStr, const OID& dictOid = 0, bool autoincrement = false);
@@ -230,7 +224,7 @@ public:
      * @param colOldValueList column old values list (return value)
      * @param rowIdList row id list
      */
-    EXPORT int deleteRow(const TxnID& txnid, std::vector<ColStructList>& colExtentsStruct,
+    EXPORT int deleteRow(const TxnID& txnid, const std::vector<CSCTypesList>& colExtentsColType, std::vector<ColStructList>& colExtentsStruct,
                          std::vector<void*>& colOldValueList, std::vector<RIDList>& ridLists, const int32_t tableOid);
 
     /**
@@ -326,6 +320,7 @@ public:
      * @param isFirstBatchPm to track if this batch is first batch for this PM.
      */
     EXPORT int insertColumnRecs(const TxnID& txnid,
+                                const CSCTypesList& cscColTypeList,
                                 ColStructList& colStructList,
                                 ColValueList& colValueList,
                                 DctnryStructList& dctnryStructList,
@@ -359,6 +354,7 @@ public:
      * @param dicStringListt dictionary values list
      */
     EXPORT int insertColumnRec_SYS(const TxnID& txnid,
+                                   const CSCTypesList& cscColTypeList,
                                    ColStructList& colStructList,
                                    ColValueList& colValueList,
                                    DctnryStructList& dctnryStructList,
@@ -372,7 +368,7 @@ public:
      * @param dicStringListt dictionary values list
      */
     EXPORT int insertColumnRec_Single(const TxnID& txnid,
-                                      CSCTypesList& cscColTypesList,
+                                      const CSCTypesList& cscColTypeList,
                                       ColStructList& colStructList,
                                       ColValueList& colValueList,
                                       DctnryStructList& dctnryStructList,
@@ -550,6 +546,7 @@ public:
      * @param ridList row id list
      */
     EXPORT int updateColumnRec(const TxnID& txnid,
+                               const std::vector<CSCTypesList>& colExtentsColType,
                                std::vector<ColStructList>& colExtentsStruct,
                                ColValueList& colValueList,
                                std::vector<void*>& colOldValueList,
@@ -566,6 +563,7 @@ public:
       */
 
     EXPORT int updateColumnRecs(const TxnID& txnid,
+                                const CSCTypesList& cscColTypeList,
                                 std::vector<ColStruct>& colStructList,
                                 ColValueList& colValueList,
                                 const RIDList& ridLists,
@@ -657,10 +655,10 @@ private:
    void findSmallestColumn(uint32_t &colId, ColStructList colStructList);
 
    /**
-     * @brief Convert interface column type to a internal column type
+     * @brief Convert interface column type to an internal column type
      */
-    void convertValue(const execplan::CalpontSystemCatalog::ColType &fullColType, ColType colType, void* valArray, size_t pos, boost::any& data, bool fromList = true);
-    void convertValue(const ColType colType, void* valArray, size_t pos, boost::any& data, bool fromList = true);
+    void convertValue(const execplan::CalpontSystemCatalog::ColType& cscColType, ColType colType, void* valArray, size_t pos, boost::any& data, bool fromList = true);
+
     /**
      * @brief Convert column value to its internal representation
      *
@@ -668,8 +666,7 @@ private:
      * @param value Memory pointer for storing output value. Should be pre-allocated
      * @param data Column data
      */
-    void convertValue(const execplan::CalpontSystemCatalog::ColType &fullColType, const ColType colType, void* value, boost::any& data);
-    void convertValue(const ColType colType, void* value, boost::any& data);
+    void convertValue(const execplan::CalpontSystemCatalog::ColType& cscColType, const ColType colType, void* value, boost::any& data);
 
     /**
      * @brief Print input value from DDL/DML processors
@@ -705,14 +702,6 @@ private:
                        RID* rowIdArray, const ColStructList& newColStructList,
                        ColValueList& newColValueList, const int32_t tableOid,
                        bool useTmpSuffix, bool versioning = true);
-    // WIP
-    int writeColumnRec(const TxnID& txnid,
-                       const ColStructList& colStructList,
-                       ColValueList& colValueList,
-                       RID* rowIdArray, const ColStructList& newColStructList,
-                       ColValueList& newColValueList, const int32_t tableOid,
-                       bool useTmpSuffix, bool versioning = true);
-
 
     int writeColumnRecBinary(const TxnID& txnid, const ColStructList& colStructList,
                              std::vector<uint64_t>& colValueList,
@@ -721,24 +710,17 @@ private:
                              const int32_t tableOid,
                              bool useTmpSuffix, bool versioning = true);
 
-
     //@Bug 1886,2870 pass the address of ridList vector
     int writeColumnRec(const TxnID& txnid, 
-                       const CSCTypesList& cscColTypes,
+                       const CSCTypesList& cscColTypeList,
                        const ColStructList& colStructList,
                        const ColValueList& colValueList, std::vector<void*>& colOldValueList,
                        const RIDList& ridList, const int32_t tableOid,
                        bool convertStructFlag = true, ColTupleList::size_type nRows = 0);
-    // WIP legacy
-    int writeColumnRec(const TxnID& txnid, 
-                       const ColStructList& colStructList,
-                       const ColValueList& colValueList, std::vector<void*>& colOldValueList,
-                       const RIDList& ridList, const int32_t tableOid,
-                       bool convertStructFlag = true, ColTupleList::size_type nRows = 0);
-
 
     //For update column from column to use
-    int writeColumnRecords(const TxnID& txnid, std::vector<ColStruct>& colStructList,
+    int writeColumnRecords(const TxnID& txnid, const CSCTypesList& cscColTypeList,
+                           std::vector<ColStruct>& colStructList,
                            ColValueList& colValueList, const RIDList& ridLists,
                            const int32_t tableOid, bool versioning = true);
 


### PR DESCRIPTION
This PR adds support for multi-value inserts, as well as deletes. It also refactors writeengine code to remove duplication for convertValArray(), convertValue(), writeColumnRec().

Here are some SQL queries to demonstrate this support:

```sql
MariaDB [test]> create table d1 (a decimal(38))engine=columnstore;
Query OK, 0 rows affected (0.245 sec)

MariaDB [test]> insert into d1 values (12345678901234567890123456789012345678), (99999999999999999999999999999999999999), (123);
Query OK, 3 rows affected (0.276 sec)
Records: 3  Duplicates: 0  Warnings: 0

MariaDB [test]> select a from d1;
+----------------------------------------+
| a                                      |
+----------------------------------------+
| 12345678901234567890123456789012345678 |
| 99999999999999999999999999999999999999 |
|                                    123 |
+----------------------------------------+
3 rows in set (0.159 sec)

MariaDB [test]> delete from d1 where a > 12345678901234567890123456789012345678;
Query OK, 1 row affected (0.388 sec)

MariaDB [test]> select a from d1;
+----------------------------------------+
| a                                      |
+----------------------------------------+
| 12345678901234567890123456789012345678 |
|                                    123 |
+----------------------------------------+
2 rows in set (0.047 sec)

MariaDB [test]> delete from d1;
Query OK, 2 rows affected (0.142 sec)

MariaDB [test]> select a from d1;
Empty set (0.020 sec)

```