### PR TITLE
fix : multithreading error

### DIFF
--- a/utils/jit/jit.cpp
+++ b/utils/jit/jit.cpp
@@ -329,6 +329,7 @@ JIT::JIT()
 
 JIT::CompiledModule JIT::compileModule(std::function<void(llvm::Module&)> compile_function)
 {
+  std::lock_guard<std::mutex> lock(jit_lock);
   auto module = createModuleForCompilation();
   compile_function(*module);
   auto module_info = compileModule(std::move(module));

--- a/utils/jit/jit.h
+++ b/utils/jit/jit.h
@@ -40,7 +40,6 @@ class JIT
   std::unordered_map<uint64_t, std::unique_ptr<JITModuleMemoryManager>> module_identifier_to_memory_manager;
   std::atomic<size_t> current_module_key{0};
   std::atomic<size_t> compiled_code_size;
-  // TODO lock when compiling a module
   mutable std::mutex jit_lock;
 };
 }  // namespace msc_jit


### PR DESCRIPTION
If the amount of data is large enough(such as 50w lines), the multi-threaded compilation module will report an error.